### PR TITLE
Replace deprecated pypy3 with pypy-3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 # Supported CPython versions:
 # https://en.wikipedia.org/wiki/CPython#Version_history
 python:
- - pypy3
+ - pypy-3.8
  - pypy
  - 2.7
  - 3.6
@@ -36,7 +36,7 @@ script:
 matrix:
   fast_finish: true
   allow_failures:
-   - python: pypy3
+   - python: pypy-3.8
    - python: 3.6
    - python: 3.5
    - python: 3.4


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos